### PR TITLE
Refactor TimeEstimator logging parameter

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -43,7 +43,7 @@ class PocatTrainer:
             raise NotImplementedError
             
         self.start_epoch = 1
-        self.time_estimator = TimeEstimator(logger=args.log)
+        self.time_estimator = TimeEstimator(log_fn=args.log)
 
     def run(self):
         args = self.args

--- a/utils/common.py
+++ b/utils/common.py
@@ -13,8 +13,8 @@ from tensordict import TensorDict
 class TimeEstimator:
     """ 훈련 시간 및 남은 시간을 예측하는 클래스 """
 
-    def __init__(self, logger=None):
-        self.logger = logger if logger else logging.getLogger('TimeEstimator')
+    def __init__(self, log_fn=None):
+        self.log = log_fn or logging.getLogger('TimeEstimator').info
         self.start_time = time.time()
         self.count_zero = 0
 
@@ -46,7 +46,7 @@ class TimeEstimator:
 
     def print_est_time(self, count, total):
         elapsed_str, remain_str = self.get_est_string(count, total)
-        self.logger.info(
+        self.log(
             f"Epoch {count:3d}/{total:3d}: Time Est.: Elapsed[{elapsed_str}], Remain[{remain_str}]"
         )
 


### PR DESCRIPTION
## Summary
- Refactor `TimeEstimator` to accept a `log_fn` callable, defaulting to the logger's `info` method
- Update trainer to instantiate `TimeEstimator` with the new `log_fn` parameter

## Testing
- `python -m py_compile utils/common.py trainer.py`
- `python run.py --config_yaml config_small.yaml --batch_size 2 --config_file config.json` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not connect to proxy - 403 Forbidden)*
- `pip install torch` *(fails: Could not connect to proxy - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a28d37c83299d5475c7d31e6890